### PR TITLE
Dramatically more detailed CRL auditing

### DIFF
--- a/crlite_status/status.py
+++ b/crlite_status/status.py
@@ -16,9 +16,17 @@ kIdentifierFormat = re.compile(r"(\d{8}-\d+)/?")
 
 parser = argparse.ArgumentParser()
 parser.add_argument("count", help="Number of entries", type=int)
-parser.add_argument("--crl", help="Evaluate CRL audits", action="store_true")
-parser.add_argument("--crl-details", help="Path for HTML details", type=Path)
-parser.add_argument(
+crl_group = parser.add_argument_group(
+    title="Evaluate CRLs", description="Download CRL audit data and analyze it"
+)
+crl_group.add_argument("--crl", help="Evaluate CRL audits", action="store_true")
+crl_group.add_argument("--crl-details", help="Path for HTML details", type=Path)
+crl_group.add_argument(
+    "--crl-details-all",
+    help="Print details for every CRL, even trivially valid ones",
+    action="store_true",
+)
+crl_group.add_argument(
     "--auditdb",
     help="Path to store CRL audits",
     type=Path,
@@ -137,11 +145,11 @@ def size_to_str(sz_str):
     return f"{sz:,} B"
 
 
-def is_enrolled(issuer_subject, *, runinfo={}):
+def is_enrolled(issuerPubKeyHash, *, runinfo={}):
     if "enrolled" not in runinfo:
         return "Unknown"
     for issuer in runinfo["enrolled"]:
-        if issuer_subject == issuer["pubKeyHash"]:
+        if issuerPubKeyHash == issuer["pubKeyHash"]:
             if issuer["enrolled"]:
                 return "✅"
             return "❌"
@@ -276,7 +284,8 @@ def main():
         )
     console.print(size_table)
 
-    if args.crl or args.crl_details:
+    if args.crl or args.crl_details or args.crl_details_all:
+        summary_tables = list()
         detail_console = Console(file=io.StringIO(), record=True)
 
         for run_id in all_runs:
@@ -285,8 +294,11 @@ def main():
                 is_important_crl_audit_entry, run_info[run_id]["crl_audit"]["Entries"]
             ):
                 if entry["IssuerSubject"] not in issuer_to_crl_audit:
-                    issuer_to_crl_audit[entry["IssuerSubject"]] = []
-                issuer_to_crl_audit[entry["IssuerSubject"]].append(entry)
+                    issuer_to_crl_audit[entry["IssuerSubject"]] = {
+                        "crls": [],
+                        "issuerPubKeyHash": entry["Issuer"],
+                    }
+                issuer_to_crl_audit[entry["IssuerSubject"]]["crls"].append(entry)
 
             table = Table(title=f"{run_id} CRL Audit Entries", show_header=True)
             table.add_column("Issuer")
@@ -297,28 +309,61 @@ def main():
             detail_console.rule(f"{run_id} CRL Audit Entries")
 
             for issuerSubject in issuer_to_crl_audit:
-                for kind, entries in itertools.groupby(
-                    sorted(issuer_to_crl_audit[issuerSubject], key=lambda x: x["Kind"]),
+                enrolled = is_enrolled(
+                    issuer_to_crl_audit[issuerSubject]["issuerPubKeyHash"],
+                    runinfo=run_info[run_id],
+                )
+
+                for kind, crls in itertools.groupby(
+                    sorted(
+                        issuer_to_crl_audit[issuerSubject]["crls"],
+                        key=lambda x: x["Kind"],
+                    ),
                     key=lambda x: x["Kind"],
                 ):
-                    entries_list = list(entries)
-                    num_entries = len(entries_list)
-                    first_entry = entries_list[0]
+                    num_entries = len(list(crls))
                     table.add_row(
                         issuerSubject,
                         kind,
                         str(num_entries),
-                        is_enrolled(first_entry["Issuer"], runinfo=run_info[run_id]),
+                        enrolled,
                     )
 
-                for entry in issuer_to_crl_audit[issuerSubject]:
-                    detail_console.print(entry)
+                issuer_table = Table(title=f"{issuerSubject} CRLs", show_header=True)
+                issuer_table.add_column("URL")
+                issuer_table.add_column("Statuses")
+                issuer_table.add_column("Enrolled")
+                issuer_table.add_column("Details")
+
+                for url, entries_grp in itertools.groupby(
+                    issuer_to_crl_audit[issuerSubject]["crls"], key=lambda x: x["Url"]
+                ):
+                    entries = list(entries_grp)
+                    statuses = list(map(lambda x: x["Kind"], entries))
+
+                    if (
+                        len(statuses) == 1
+                        and "Valid, Processed" in statuses
+                        and not args.crl_details_all
+                    ):
+                        continue
+
+                    issuer_table.add_row(
+                        url,
+                        f"{statuses}",
+                        enrolled,
+                        f"{entries}",
+                    )
+                    detail_console.print(issuer_table)
 
             console.print(table)
-            detail_console.print(table)
+            summary_tables.append(table)
 
         if args.crl_details:
             console.log(f"Writing CRL details to {args.crl_details}")
+            detail_console.rule(f"Summary Tables")
+            for table in summary_tables:
+                detail_console.print(table)
             detail_console.save_html(args.crl_details)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="crlite_status",
-    version="0.0.5",
+    version="0.0.6",
     description="Query CRLite status",
     long_description="Use this tool get information about recent CRLite runs",
     classifiers=[


### PR DESCRIPTION
Fixes #2

Per-CRL URL, emit the details about how each CRL was processed, and change the detail table formats to expose the number of CRLs that fail, recover, or are successfully updated.



